### PR TITLE
[#4] Accept code.xml and .catrobat file extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
       "integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg=="
     },
+    "adm-zip": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+    },
     "array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {},
   "dependencies": {
+    "adm-zip": "^0.4.13",
     "binary-search-insert": "^1.0.3",
     "command-line-args": "^5.0.2",
     "fs-extra": "^8.0.1",

--- a/src/program-stats.js
+++ b/src/program-stats.js
@@ -5,7 +5,7 @@ import xmldom from 'xmldom';
 import xpath from 'xpath';
 import {parentPort, workerData} from 'worker_threads';
 
-import {increaseObjectKey} from './utils';
+import {getCodeXmlStringFromFile, increaseObjectKey} from './utils';
 import statsInfo, {featureGroups} from './stats-info';
 
 const parser = new xmldom.DOMParser();
@@ -183,6 +183,6 @@ function getFormulaFeatures(id) {
 
 parentPort.on('message', (file) => {
     console.log(workerData.id, file);
-    parentPort.postMessage(getProgramStatsFromFile(file));
+    parentPort.postMessage(getProgramStatsFromString(getCodeXmlStringFromFile(file)));
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,9 @@
 'use strict';
 
+import path from 'path';
+import fs from 'fs';
+import AdmZip from 'adm-zip';
+
 export const increaseObjectKey = (o, key, by = 1) => o[key] = (o[key] || 0) + by;
 
 export const pushIfDefined = (array, value) => {
@@ -7,3 +11,26 @@ export const pushIfDefined = (array, value) => {
         array.push(value);
     }
 };
+
+export function getExtension(file) {
+    const ext = path.extname(file || '').split('.');
+    return ext[ext.length - 1];
+}
+
+export function getCodeXmlStringFromFile(file) {
+    let xmlString;
+    switch (getExtension(file)) {
+        case 'xml':
+            xmlString = fs.readFileSync(file, 'UTF-8');
+            break;
+        case 'catrobat':
+        case 'zip':
+            xmlString = new AdmZip(file).getEntries().find(function(zipEntry) {
+                return zipEntry.entryName === 'code.xml';
+            }).getData().toString('utf8');
+            break;
+        default:
+            throw new Error(`${file} has unknown file extension ${getExtension(file)}`);
+    }
+    return xmlString;
+}


### PR DESCRIPTION
All programs must have a /program/header/url set, which only the official
share server will do. As workaround you can

- Set the /program/header/url to a valid url manually.
- Use the code.xml file and rename it following the format
  MILLISECONDS_ID.xml, e.g. 1364288279000_710.xml.

Use a unique id for each program, otherwise they may not show up in the
statistics.

The upload date for code.xml and .catrobat files can't be determined, so
new Date(0) is used. Such programs will appear only in the overall
statistics, not in the monthly or yearly ones.